### PR TITLE
Better, more resilient error handling.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -319,7 +319,7 @@ impl Plugin {
         let url = format!("{}", self);
         let archive = recv_bytes_retry(&url)
             .await
-            .with_context(|| format!("failed downloading plugin {}", self))?;
+            .with_context(|| "failed downloading plugin")?;
 
         s.send(InstallState {
             status: InstallStateKind::Extracting,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -307,7 +307,6 @@ async fn recv_bytes_retry(url: &str) -> Result<Vec<u8>> {
 impl Plugin {
     async fn install_plugin(&self, path: PathBuf, s: sync::Sender<InstallState>) -> Result<()> {
         use anyhow::Context;
-        use std::process;
 
         let name = self.get_name();
 


### PR DESCRIPTION
This PR (fixes #8) stops plugin installation errors from being bubbled up to `main`, thereby letting one plugin install fail while the others continue. These errors are displayed conveniently next to the plugin’s spinner, making it easy to see which plugin install failed.